### PR TITLE
Feat add order endpoints

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -4,6 +4,7 @@ from app.api.v1.auth import auth_router
 from app.api.v1.keys import keys_router
 from app.api.v1.models import model_router
 from app.api.v1.orders import order_router
+from app.api.v1.pose_sets import pose_sets_router
 from app.api.v1.poses import pose_router
 from app.config import Config
 
@@ -27,3 +28,4 @@ router.include_router(keys_router)
 router.include_router(order_router)
 router.include_router(model_router)
 router.include_router(pose_router)
+router.include_router(pose_sets_router)

--- a/app/api/v1/models/model_routes.py
+++ b/app/api/v1/models/model_routes.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter, Body, Depends, Form, Request, UploadFile
+from fastapi import APIRouter, Depends, Form, Request, UploadFile
 from pydantic import HttpUrl
 from typing_extensions import TypedDict
 
@@ -30,13 +30,6 @@ def get_models(request: Request) -> DataResponse:
 
 
 @router.post("/new", dependencies=[Depends(JWTBearer(Role.ADMIN))])
-def create_model(model: ModelInsert = Body(...)):
-    return supabase.table("models").insert(json={
-        **model.model_dump(),
-    }).execute()
-
-
-@router.post("/new/images", dependencies=[Depends(JWTBearer(Role.ADMIN))])
 def create_model_with_images(images: list[UploadFile], name: str = Form(), tensor_file_url: Optional[HttpUrl] = Form(None)) -> ModelWithImagesResponse:
     model = ModelInsert(name=name, tensor_file_url=tensor_file_url)
 

--- a/app/api/v1/orders/order_routes.py
+++ b/app/api/v1/orders/order_routes.py
@@ -1,27 +1,96 @@
-from fastapi import APIRouter, Body, Depends, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
+from typing_extensions import TypedDict
 
 from app.middlewares import JWTBearer
 from app.repositories import supabase
-from app.schemas import OrderInsert
+from app.schemas import Order, OrderInsert, OrderWithData
 
 router = APIRouter(
     prefix="/orders", tags=["orders"], dependencies=[Depends(JWTBearer())])
 
+OrderResponse = TypedDict("OrderResponse", {"data": Order, "count": int})
+OrdersResponse = TypedDict(
+    "OrdersResponse", {"data": list[Order], "count": int})
+OrderWithDataResponse = TypedDict("OrderWithDataResponse", {
+                                  "data": OrderWithData, "count": int})
+OrdersWithDataResponse = TypedDict("OrdersWithDataResponse", {
+                                   "data": list[OrderWithData], "count": int})
+
 
 @router.get("/")
-def get_orders(request: Request):
+def get_orders(request: Request) -> OrdersResponse:
     user_id = request.state.user
-    role = request.state.role
-    print(user_id)
-    return supabase.table("orders").select("*").eq("user_id", user_id).execute()
+
+    orders_res = supabase.table("orders").select(
+        "*").eq("user_id", user_id).execute()
+
+    orders = [Order(**order) for order in orders_res.data]
+
+    return {"data": orders, "count": len(orders)}
+
+
+@router.get("/{order_id}")
+def get_order(request: Request, order_id: int) -> OrderResponse:
+    user_id = request.state.user
+
+    print("Order ID", order_id)
+
+    order_res = supabase.table("orders").select(
+        "*").eq("user_id", user_id).eq("id", order_id).execute()
+
+    if len(order_res.data) == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Order {order_id} not found.")
+
+    order = Order(**order_res.data[0])
+
+    return {"data": order, "count": 1}
+
+
+@router.get("/with-data")
+def get_orders_with_data(request: Request) -> OrdersWithDataResponse:
+    user_id = request.state.user
+
+    orders_res = supabase.table("orders").select(
+        "*,model:models(*,images(*)),pose_set:pose_sets(*,poses(*,cover_image:images!poses_image_fkey(*),skeleton_image:images!poses_skeleton_image_fkey(*)))"
+    ).eq("user_id", user_id).execute()
+
+    print(orders_res.data)
+
+    orders = [OrderWithData(**order) for order in orders_res.data]
+
+    return {"data": orders, "count": len(orders)}
+
+
+@router.get("/{order_id}/with-data")
+def get_order_with_data(request: Request, order_id: int) -> OrderWithDataResponse:
+    user_id = request.state.user
+
+    print("Order ID", order_id)
+
+    order_res = supabase.table("orders").select(
+        "*,model:models(*,images(*)),pose_set:pose_sets(*,poses(*,cover_image:images!poses_image_fkey(*),skeleton_image:images!poses_skeleton_image_fkey(*)))"
+    ).eq("user_id", user_id).eq("id", order_id).execute()
+
+    if len(order_res.data) == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Order {order_id} not found.")
+
+    order = OrderWithData(**order_res.data[0])
+
+    return {"data": order, "count": 1}
 
 
 @router.post("/new")
-def create_order(request: Request, order: OrderInsert = Body(...)):
+def create_order(request: Request, order: OrderInsert = Body(...)) -> OrderResponse:
     user_id = request.state.user
     role = request.state.role
 
-    return supabase.table("orders").insert(json={
+    order_res = supabase.table("orders").insert(json={
         **order.model_dump(),
         "user_id": user_id,
     }).execute()
+
+    order_created = Order(**order_res.data[0])
+
+    return {"data": order_created, "count": 1}

--- a/app/api/v1/pose_sets/__init__.py
+++ b/app/api/v1/pose_sets/__init__.py
@@ -1,0 +1,1 @@
+from app.api.v1.pose_sets.pose_sets_routes import router as pose_sets_router

--- a/app/api/v1/pose_sets/pose_sets_routes.py
+++ b/app/api/v1/pose_sets/pose_sets_routes.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Body, Depends, Request
+
+from app.middlewares import JWTBearer, Role
+from app.repositories import supabase
+from app.schemas import PoseSet, PoseSetInsert, PoseSetWithPoses
+
+router = APIRouter(
+    prefix="/pose_sets", tags=["pose sets"], dependencies=[Depends(JWTBearer())])
+
+
+@router.get("/")
+def get_pose_sets(request: Request):
+    res = supabase.table("pose_sets").select(
+        "*,poses(*,cover_image:images!poses_image_fkey(*),skeleton_image:images!poses_skeleton_image_fkey(*))").execute()
+
+    pose_sets_with_poses = [PoseSetWithPoses(**pose_set)
+                            for pose_set in res.data]
+
+    return {"data": pose_sets_with_poses, "count": len(pose_sets_with_poses)}
+
+
+@router.post("/new", dependencies=[Depends(JWTBearer(Role.ADMIN))])
+def create_pose_set(new_pose_set: PoseSetInsert = Body(...)):
+    pose_res = supabase.table("pose_sets").insert(
+        json={"name": new_pose_set.name}).execute()
+
+    pose_set = PoseSet(**pose_res.data[0])
+
+    pose_set_poses_res = supabase.table("pose_sets_poses").insert(json=[
+        {"set_id": pose_set.id, "pose_id": pose} for pose in new_pose_set.poses
+    ]).execute()
+
+    pose_set_with_poses_res = supabase.table("pose_sets").select(
+        "*,poses(*,cover_image:images!poses_image_fkey(*),skeleton_image:images!poses_skeleton_image_fkey(*))").eq("id", pose_set.id).single().execute()
+
+    print(pose_set_with_poses_res.data)
+
+    pose_set_with_poses = PoseSetWithPoses(**pose_set_with_poses_res.data)
+
+    return {"data": pose_set_with_poses, "count": 1}

--- a/app/api/v1/poses/pose_routes.py
+++ b/app/api/v1/poses/pose_routes.py
@@ -1,14 +1,13 @@
-from fastapi import APIRouter, Body, Depends, Form, HTTPException, Request, UploadFile, status
-
+from fastapi import (APIRouter, Body, Depends, Form, HTTPException, Request,
+                     UploadFile, status)
 from pydantic import HttpUrl
 from typing_extensions import TypedDict
 
+from app.common import StorageFolder, upload_images_to_storage
 from app.config import Config
-
 from app.middlewares import JWTBearer, Role
 from app.repositories import supabase
-from app.common import StorageFolder, upload_images_to_storage
-from app.schemas import Image
+from app.schemas import Image, PoseSet, PoseSetInsert, PoseSetWithPoses
 
 router = APIRouter(
     prefix="/poses", tags=["poses"], dependencies=[Depends(JWTBearer())])

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -3,5 +3,6 @@ from app.schemas.images_schemas import Image, ImageInsert, ImageKey, ImageType
 from app.schemas.keys_schemas import Key, KeyInsert
 from app.schemas.model_schemas import (Model, ModelInsert, ModelInsertForm,
                                        ModelWithImages)
-from app.schemas.order_schemas import Order, OrderInsert
-from app.schemas.pose_schemas import PoseSet, PoseSetInsert, Pose, PoseSetWithPoses
+from app.schemas.order_schemas import Order, OrderInsert, OrderWithData
+from app.schemas.pose_schemas import (Pose, PoseSet, PoseSetInsert,
+                                      PoseSetWithPoses)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,3 +4,4 @@ from app.schemas.keys_schemas import Key, KeyInsert
 from app.schemas.model_schemas import (Model, ModelInsert, ModelInsertForm,
                                        ModelWithImages)
 from app.schemas.order_schemas import Order, OrderInsert
+from app.schemas.pose_schemas import PoseSet, PoseSetInsert, Pose, PoseSetWithPoses

--- a/app/schemas/order_schemas.py
+++ b/app/schemas/order_schemas.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_serializer
 
+from app.schemas.model_schemas import ModelWithImages
+from app.schemas.pose_schemas import PoseSetWithPoses
 from app.utils.patterns import UUIDV4_PATTERN
 
 
@@ -17,6 +19,7 @@ class OrderStatus(str, Enum):
 
 class OrderBase(BaseModel):
     model: int = Field(gt=0)
+    pose_set: int = Field(gt=0)
 
 
 class OrderInsert(OrderBase):
@@ -32,3 +35,8 @@ class Order(OrderBase):
     @field_serializer('created_at')
     def serialize_datetime(v, _info):
         return v.isoformat(sep='T', timespec='seconds')  # type: ignore
+
+
+class OrderWithData(Order):
+    model: ModelWithImages
+    pose_set: PoseSetWithPoses

--- a/app/schemas/pose_schemas.py
+++ b/app/schemas/pose_schemas.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_serializer
+
+from app.schemas.images_schemas import Image
+
+
+class PoseBase(BaseModel):
+    name: str = Field(examples=["Pose 1"])
+
+
+class Pose(PoseBase):
+    id: int = Field(examples=[1])
+    cover_image: int = Field(examples=[1])
+    skeleton_image: int = Field(examples=[2])
+    created_at: datetime = Field(...)
+
+    @field_serializer('created_at')
+    def serialize_datetime(v, _info):
+        return v.isoformat(sep='T', timespec='seconds')  # type: ignore
+
+
+class PoseSetBase(BaseModel):
+    name: str = Field(examples=["Pose Set 1"])
+
+
+class PoseSetInsert(PoseSetBase):
+    poses: list[int] = Field(examples=[[1, 2, 3, 4, 5]])
+
+
+class PoseSet(PoseSetBase):
+    id: int = Field(examples=[1])
+    created_at: datetime = Field(...)
+
+    @field_serializer('created_at')
+    def serialize_datetime(v, _info):
+        return v.isoformat(sep='T', timespec='seconds')  # type: ignore
+
+
+class PoseWithImages(Pose):
+    cover_image: Image = Field(...)
+    skeleton_image: Image = Field(...)
+
+
+class PoseSetWithPoses(PoseSet):
+    poses: list[PoseWithImages] = Field(...)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.api.v1 import router as api_v1_router
 from app.exeptions import SupabaseException
@@ -39,8 +39,12 @@ def create_app() -> FastAPI:
         allow_headers=["*"]
     )
 
+    @app.get("/")
+    def index():
+        return RedirectResponse(url="/api/v1")
+
     # Load routers
-    app.include_router(api_v1_router)
+    app.include_router(api_v1_router, prefix="/api")
     # app.include_router(api_orders_router)
     # app.include_router(api_users_router)
     return app

--- a/supabase/migrations/20230819151256_alter_pose_sets_table_add_many_poses.sql
+++ b/supabase/migrations/20230819151256_alter_pose_sets_table_add_many_poses.sql
@@ -1,0 +1,25 @@
+ALTER TABLE pose_sets
+DROP COLUMN pose_1;
+
+ALTER TABLE pose_sets
+DROP COLUMN pose_2;
+
+ALTER TABLE pose_sets
+DROP COLUMN pose_3;
+
+ALTER TABLE pose_sets
+DROP COLUMN pose_4;
+
+CREATE TABLE
+    pose_sets_poses (
+        set_id BIGINT NOT NULL REFERENCES pose_sets (id) ON DELETE CASCADE,
+        pose_id BIGINT NOT NULL REFERENCES poses (id) ON DELETE CASCADE,
+        created_at TIMESTAMP
+        WITH
+            TIME ZONE DEFAULT timezone ('utc'::TEXT, NOW ()) NOT NULL,
+            PRIMARY KEY (set_id, pose_id)
+    );
+
+ALTER TABLE pose_sets_poses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Enable read access for all users" ON pose_sets_poses AS PERMISSIVE FOR ALL TO public USING (true);


### PR DESCRIPTION
- Now the `http://[host]/` redirect to `http://[host]/api/v1`.
- Replace `/new/images` with `/new` model routes.
- It is now possible to create `pose_sets` with more than one pose.
- Added new `pose_sets_poses` between table.
- Delete `pose_1`, `pose_2`, `pose_3` and `pose_4` columns from `pose_sets` table.
- Added poses routes, `GET`, `POST`.
- Added pose sets routes, `GET`, `POST`.
- Added schemas for manage poses and pose sets.
- Added endpoint for create a new order.
- Added enspoints for get order and orders info, simple and complete.