### PR TITLE
Add orders resume.

### DIFF
--- a/app/config/config.py
+++ b/app/config/config.py
@@ -41,3 +41,4 @@ class Config(metaclass=SingletonMeta):
         self.JWT_SECRET = os.getenv("JWT_SECRET", "")
         self.JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
         self.DEBUG = os.getenv("DEBUG", "False") == "True"
+        self.ORDER_COST = float(os.getenv("ORDER_COST", "3.50"))

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,7 +4,8 @@ from app.schemas.keys_schemas import Key, KeyInsert
 from app.schemas.model_schemas import (Model, ModelInsert, ModelInsertForm,
                                        ModelWithImages)
 from app.schemas.order_schemas import (Order, OrderComplete, OrderInsert,
-                                       OrderItem, OrderItemInsert, OrderStatus,
-                                       OrderUpdateStatus, OrderWithData)
+                                       OrderItem, OrderItemInsert, OrderResume,
+                                       OrderStatus, OrderUpdateStatus,
+                                       OrderWithData)
 from app.schemas.pose_schemas import (Pose, PoseSet, PoseSetInsert,
                                       PoseSetWithPoses)

--- a/app/schemas/order_schemas.py
+++ b/app/schemas/order_schemas.py
@@ -81,3 +81,13 @@ class OrderWithData(Order):
     model: ModelWithImages
     pose_set: PoseSetWithPoses
     items: list[OrderItemWithData]
+
+
+class OrderResume():
+    id: int = Field(gt=0)
+    status: OrderStatus = Field(...)
+    created_at: datetime = Field(...)
+
+    @field_serializer('created_at')
+    def serialize_datetime(v, _info):
+        return v.isoformat(sep='T', timespec='seconds')  # type: ignore


### PR DESCRIPTION
- Added `OrderResume` schema form logical validations.
- Fixed `OrderResume` imports.
- Added `ORDER_COST` env to `Config` class.
- Added `OrderResumeValues` and `OrdersResumeResponse` types for return method.
- Added `/api/v1/orders/resume` endpoint.
- Added `date` filter to resume orders.
- Added the calculation of the **estimated** cost of **completed** orders.