### PR TITLE
Now the update status receive metadata.

### DIFF
--- a/app/api/v1/orders/order_routes.py
+++ b/app/api/v1/orders/order_routes.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import cast
+from typing import Any, cast
 
 from fastapi import (APIRouter, Body, Depends, Form, HTTPException, Request,
                      UploadFile, status)
@@ -134,9 +134,15 @@ def update_order_status(request: Request, order_id: int, new_status: OrderUpdate
 
     order = Order(**order_res.data[0])
 
-    order_res = supabase.table("orders").update(json={
-        "status": new_status.status
-    }).eq("id", order.id).execute()
+    new_data: dict[str, Any] = {
+        "status": new_status.status,
+    }
+
+    if new_status.metadata:
+        new_data["metadata"] = new_status.metadata
+
+    order_res = supabase.table("orders").update(
+        json=new_data).eq("id", order.id).execute()
 
     order_updated = Order(**order_res.data[0])
 

--- a/app/schemas/order_schemas.py
+++ b/app/schemas/order_schemas.py
@@ -37,6 +37,7 @@ class OrderInsert(OrderBase):
 class OrderUpdateStatus(BaseModel):
     status: OrderStatus = Field(default=OrderStatus.COMPLETED)
     process_id: Optional[str] = Field(max_length=100, default=None)
+    metadata: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class OrderComplete(BaseModel):

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def load_exception_handlers(app: FastAPI) -> None:
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="DressUp API - DIGO", version="1.5.1",
+    app = FastAPI(title="DressUp API - DIGO", version="1.5.2",
                   description="This is the API for the DressUp project.", docs_url=None)
 
     app.mount("/static", StaticFiles(directory="static"), name="static")


### PR DESCRIPTION
- Added `metadata` param in `OrderUpdateStatus` schema class.
- Modified `/orders/{order_id}/update-status` endpoint for update metadata if exists in body request.